### PR TITLE
Remove DataInterpolations 5.0 workaround

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-DataInterpolations = "4, 5"
+DataInterpolations = "5.1"
 InteractiveUtils = "1"
 LinearAlgebra = "1"
 Logging = "1"

--- a/src/dynamics/orbital_evolution.jl
+++ b/src/dynamics/orbital_evolution.jl
@@ -77,10 +77,9 @@ function uniform_in_phase(solution, saves_per_orbit)
         Φ = solution[:Φ]
         δΦ = 2π / saves_per_orbit
         Φrange = range(extrema(Φ)..., step=δΦ)
-        # Call to `convert` is hack to work around DataInterpolations 5.0 bug
-        t_Φ = convert(typeof(t), CubicSpline(t, Φ)(collect(Φrange)))
-        # Hack to ensure that t=0 is interpolated back
-        # to exactly t=0 instead of, e.g., -1e-24:
+        t_Φ = CubicSpline(t, Φ)(Φrange)
+        # Ensure that t=0 is interpolated back
+        # to *exactly* t=0 instead of, e.g., -1e-24:
         t_Φ[1] = t[1]
         solution(t_Φ)
     end


### PR DESCRIPTION
Now that DataInterpolations 5.1 is out, interpolations are type stable again.  Closes #40.