### PR TITLE
Lower warning threshold for orbital evolution to 0.35

### DIFF
--- a/src/dynamics/orbital_evolution.jl
+++ b/src/dynamics/orbital_evolution.jl
@@ -131,7 +131,7 @@ are the same, regardless.
     if we detect that PN has broken down irretrievably — for example, if one of the masses
     is no longer strictly positive, if a spin is super-extremal, or the PN velocity
     parameter `v` is decreasing, or is no longer in the range `(0,1)`.  Warnings will
-    usually only be issued if `v < 1//2`, but if `quiet=true` informational messages will be
+    usually only be issued if `v < 0.35`, but if `quiet=true` informational messages will be
     issued.
   * `Rᵢ=Rotor(1)` or `R_i`: Initial orientation of binary.
   * `approximant="TaylorT1"`: Method of evaluating the right-hand side of the evolution

--- a/src/utilities/termination_criteria.jl
+++ b/src/utilities/termination_criteria.jl
@@ -102,8 +102,9 @@ Pass `force_dtmin=true` to `solve` when using this callback.  Otherwise, the tim
 may decrease too much *within* a single time step, so that the integrator itself will quit
 before reaching this callback, leading to a less graceful exit.
 
-If this terminator is triggered while `v` is less than 1/2, a warning will always be issued;
-otherwise an `info` message will be issued only if the `quiet` flag is set to `false`.
+If this terminator is triggered while `v` is less than 0.35, a warning will always be
+issued; otherwise an `info` message will be issued only if the `quiet` flag is set to
+`false`.
 """
 function dtmin_terminator(T, quiet=false)
     sqrtϵ::T = √eps(T)  # Tricks for faster closures
@@ -115,9 +116,9 @@ function dtmin_terminator(T, quiet=false)
         message = (
             "Terminating evolution because the time-step size has become very small:\n"
             * "|dt=$(integrator.dt)| < √ϵ=$(sqrtϵ)\n"
-            * "This is only unexpected for 𝑣 ≲ 1/2; the current value is 𝑣=$v."
+            * "This is only unexpected for 𝑣 ≲ 0.35; the current value is 𝑣=$v."
         )
-        if v < 1//2
+        if v < 7//20
             @warn message
         elseif !quiet
             @info message

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -171,6 +171,11 @@ git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.0"
 
+[[deps.CommonWorldInvalidations]]
+git-tree-sha1 = "ae52d1c52048455e85a387fbee9be553ec2b68d0"
+uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
+version = "1.0.0"
+
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
 git-tree-sha1 = "b1c55339b7c6c350ee89f2c1604299660525b248"
@@ -1251,10 +1256,10 @@ weakdeps = ["ChainRulesCore"]
     SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
 
 [[deps.Static]]
-deps = ["IfElse"]
-git-tree-sha1 = "85fec8e64b6b8168d7a172d7f503c6770c7cfc08"
+deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools"]
+git-tree-sha1 = "0bbff21027dd8a107551847528127b62a35f7594"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.0.0"
+version = "1.1.0"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Requires", "SparseArrays", "Static", "SuiteSparse"]
@@ -1345,10 +1350,10 @@ uuid = "d1185830-fcd6-423d-90d6-eec64667417b"
 version = "2.1.0"
 
 [[deps.Symbolics]]
-deps = ["ADTypes", "ArrayInterface", "Bijections", "ConstructionBase", "DataStructures", "DiffRules", "Distributions", "DocStringExtensions", "DomainSets", "DynamicPolynomials", "ForwardDiff", "IfElse", "LaTeXStrings", "LambertW", "Latexify", "Libdl", "LinearAlgebra", "LogExpFunctions", "MacroTools", "Markdown", "NaNMath", "PrecompileTools", "RecipesBase", "Reexport", "Requires", "RuntimeGeneratedFunctions", "SciMLBase", "Setfield", "SparseArrays", "SpecialFunctions", "StaticArraysCore", "SymbolicIndexingInterface", "SymbolicLimits", "SymbolicUtils", "TermInterface"]
-git-tree-sha1 = "15f475e04197c901c6ef12acd81a25bfe0d7360f"
+deps = ["ADTypes", "ArrayInterface", "Bijections", "CommonWorldInvalidations", "ConstructionBase", "DataStructures", "DiffRules", "Distributions", "DocStringExtensions", "DomainSets", "DynamicPolynomials", "ForwardDiff", "IfElse", "LaTeXStrings", "LambertW", "Latexify", "Libdl", "LinearAlgebra", "LogExpFunctions", "MacroTools", "Markdown", "NaNMath", "PrecompileTools", "RecipesBase", "Reexport", "Requires", "RuntimeGeneratedFunctions", "SciMLBase", "Setfield", "SparseArrays", "SpecialFunctions", "StaticArraysCore", "SymbolicIndexingInterface", "SymbolicLimits", "SymbolicUtils", "TermInterface"]
+git-tree-sha1 = "8539a734b448ca27707709c62420b1bf115ed7d9"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "5.32.0"
+version = "5.33.0"
 
     [deps.Symbolics.extensions]
     SymbolicsGroebnerExt = "Groebner"


### PR DESCRIPTION
There are too many warnings when PN fails close to v=0.5, but not quite there.  This will quiet them.