### PR TITLE
Skip reference tests on wrong julia version

### DIFF
--- a/docs/src/internals/derived_variables.md
+++ b/docs/src/internals/derived_variables.md
@@ -184,3 +184,9 @@ PostNewtonian.λ₂
 PostNewtonian.λ₊
 PostNewtonian.λ₋
 ```
+
+## Tidal coupling
+
+```@docs
+PostNewtonian.Λ̃
+```

--- a/src/PostNewtonian.jl
+++ b/src/PostNewtonian.jl
@@ -136,7 +136,9 @@ export total_mass,  # M,  # Avoid clashes: don't export nicer names for importan
     λ₁,
     λ₂,
     λ₊,
-    λ₋
+    λ₋,
+    Λ̃,
+    Lambda_tilde
 
 include("pn_expressions.jl")
 export gw_energy_flux,

--- a/src/derived_variables.jl
+++ b/src/derived_variables.jl
@@ -75,4 +75,7 @@ include("derived_variables/horizons.jl")
 export rₕ₁,
     rₕ₂, Ωₕ₁, Ωₕ₂, sin²θ₁, sin²θ₂, ϕ̇̂₁, ϕ̇̂₂, Î₀₁, Î₀₂, κ₁, κ₂, κ₊, κ₋, λ₁, λ₂, λ₊, λ₋
 
+include("derived_variables/tidal_coupling.jl")
+export Λ̃, Lambda_tilde
+
 end

--- a/src/derived_variables/tidal_coupling.jl
+++ b/src/derived_variables/tidal_coupling.jl
@@ -1,0 +1,22 @@
+@doc raw"""
+    Λ̃(pnsystem)
+    Lambda_tilde(pnsystem)
+
+Effective tidal deformability of the system.
+
+Much as the chirp mass is a particularly measurable combination of the masses of the two
+components of the binary, this quantity is a particularly measurable combination of the
+tidal couplings ``\Lambda_1`` and ``\Lambda_2`` of the two components.
+
+[Raithel et al. (2018)](https://doi.org/10.3847/2041-8213/aabcbf) define this as
+```math
+\tilde{\Lambda} = \frac{16}{13}
+    \frac{(M_1 + 12 M_2) M_1^4 \Lambda_1 + (M_2 + 12 M_1) M_2^4 \Lambda_2} {M^5}.
+```
+
+See also [`Λ₁`](@ref) and [`Λ₂`](@ref).
+"""
+Λ̃(s::VecOrPNSystem) =
+    16//13 * ((M₁(s) + 12M₂(s)) * M₁(s)^4 * Λ₁(s) + (M₂(s) + 12M₁(s)) * M₂(s)^4 * Λ₂(s)) /
+    M(s)^5
+const Lambda_tilde = Λ̃

--- a/src/fundamental_variables.jl
+++ b/src/fundamental_variables.jl
@@ -127,9 +127,12 @@ black holes, it is precisely zero; for neutron stars it may range up to 1; more 
 objects may have significantly larger values.
 
 Note that — as of this writing — only `NSNS` systems can have a nonzero value for this
-quantity.  All other types return `0`, which Julia can use to eliminate code that would then
-be 0.  Thus, it is safe and efficient to use this quantity in any PN expression that
-specializes on the type of `pnsystem`.
+quantity.  (`BHNS` systems can only have a nonzero value for ``\Lambda_2``.)  All other
+types return `0`, which Julia can use to eliminate code that would then be 0.  Thus, it is
+safe and efficient to use this quantity in any PN expression that specializes on the type of
+`pnsystem`.
+
+See also [`Λ₂`](@ref) and [`Λ̃`](@ref).
 """
 Λ₁(pn::PNSystem) = zero(eltype(pn))
 Λ₁(pn::NSNS) = pn.Λ₁
@@ -148,6 +151,8 @@ Note that — as of this writing — only `BHNS` and `NSNS` systems can have a n
 this quantity.  All other types return `0`, which Julia can use to eliminate code that would
 then be 0.  Thus, it is safe and efficient to use this quantity in any PN expression that
 specializes on the type of `pnsystem`.
+
+See also [`Λ₁`](@ref) and [`Λ̃`](@ref).
 """
 Λ₂(pn::PNSystem) = zero(eltype(pn))
 Λ₂(pn::BHNS) = pn.Λ₂

--- a/test/reference_tests.jl
+++ b/test/reference_tests.jl
@@ -54,72 +54,78 @@
         ) by = (r, a) -> approx(r, a; atol=0, rtol=1e-15)
     end
 
-    compare_v̇("vdot.h5")
+    if VERSION.major == 1 && VERSION.minor == 11
+        @info "We are running on Julia 1.11; running reference tests."
 
-    # These tests rely too heavily on ODE integration being consistent, which seems to be
-    # highly architecture-dependent, so we disable them on CI.
-    if get(ENV, "CI", "false") == "false"
-        @info "We appear not to be on CI; running reference tests involving ODE integration."
+        compare_v̇("vdot.h5")
 
-        function compare_inspiral(file_name, args...; kwargs...)
-            file_name = joinpath("reference_values", file_name)
-            inspiral = orbital_evolution(args...; kwargs...)
-            pnsystem = try
-                inspiral.prob.p
-            catch
-                inspiral.p
+        # These tests rely too heavily on ODE integration being consistent, which seems to be
+        # highly architecture-dependent, so we disable them on CI.
+        if get(ENV, "CI", "false") == "false"
+            @info "We appear not to be on CI; running reference tests involving ODE integration."
+
+            function compare_inspiral(file_name, args...; kwargs...)
+                file_name = joinpath("reference_values", file_name)
+                inspiral = orbital_evolution(args...; kwargs...)
+                pnsystem = try
+                    inspiral.prob.p
+                catch
+                    inspiral.p
+                end
+                @test_reference file_name Dict(
+                    "2PNOrder" => Int(2pn_order(pnsystem)),
+                    "state" => pnsystem.state,
+                    "t" => inspiral.t,
+                    "u" => reduce(hcat, inspiral.u),
+                ) by = approx
             end
-            @test_reference file_name Dict(
-                "2PNOrder" => Int(2pn_order(pnsystem)),
-                "state" => pnsystem.state,
-                "t" => inspiral.t,
-                "u" => reduce(hcat, inspiral.u),
-            ) by = approx
+
+            M₁ = 0.8
+            M₂ = 0.2
+            χ⃗₁ = QuatVec(0.1, 0.2, 0.3)
+            χ⃗₂ = QuatVec(0.6, 0.4, 0.1)
+            Ωᵢ = PostNewtonian.Ω(; v=0.3, M=M₁ + M₂)
+            Ωₑ = PostNewtonian.Ω(; v=0.4, M=M₁ + M₂)
+
+            inspiral = orbital_evolution(M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; Ωₑ)
+
+            compare_inspiral("inspiral1.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ)
+            compare_inspiral("inspiral2.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; Ω₁=Ωᵢ / 2)
+            compare_inspiral("inspiral3.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; saveat=3.7)
+            compare_inspiral(
+                "inspiral4.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; saveat=inspiral.t[3:7:(end - 9)]
+            )
+            compare_inspiral("inspiral5.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; Ωₑ)
+            compare_inspiral("inspiral6.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; saves_per_orbit=3)
+            compare_inspiral("inspiral7.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=1//2)
+            compare_inspiral("inspiral8.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=3//2)
+            compare_inspiral("inspiral9.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=5//2)
+            compare_inspiral("inspiral10.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=7//2)
+
+            function compare_waveforms(
+                file_name, inspiral, f; ℓₘᵢₙ=2, ℓₘₐₓ=8, PNOrder=typemax(Int)
+            )
+                file_name = joinpath("reference_values", file_name)
+                h = f(inspiral; ℓₘᵢₙ, ℓₘₐₓ, PNOrder)
+                @test_reference file_name Dict("h" => h) by = approx
+            end
+
+            compare_waveforms("waveform1.h5", inspiral, coorbital_waveform)
+            compare_waveforms("waveform2.h5", inspiral, coorbital_waveform; ℓₘᵢₙ=1, ℓₘₐₓ=4)
+            compare_waveforms("waveform3.h5", inspiral, coorbital_waveform; PNOrder=1//2)
+            compare_waveforms("waveform4.h5", inspiral, coorbital_waveform; PNOrder=3//2)
+            compare_waveforms("waveform5.h5", inspiral, coorbital_waveform; PNOrder=5//2)
+            compare_waveforms("waveform6.h5", inspiral, coorbital_waveform; PNOrder=7//2)
+            compare_waveforms("waveform7.h5", inspiral, inertial_waveform)
+            compare_waveforms("waveform8.h5", inspiral, inertial_waveform; ℓₘᵢₙ=1, ℓₘₐₓ=4)
+            compare_waveforms("waveform9.h5", inspiral, inertial_waveform; PNOrder=1//2)
+            compare_waveforms("waveform10.h5", inspiral, inertial_waveform; PNOrder=3//2)
+            compare_waveforms("waveform11.h5", inspiral, inertial_waveform; PNOrder=5//2)
+            compare_waveforms("waveform12.h5", inspiral, inertial_waveform; PNOrder=7//2)
+        else
+            @info "We appear to be on CI; skipping reference tests involving ODE integration."
         end
-
-        M₁ = 0.8
-        M₂ = 0.2
-        χ⃗₁ = QuatVec(0.1, 0.2, 0.3)
-        χ⃗₂ = QuatVec(0.6, 0.4, 0.1)
-        Ωᵢ = PostNewtonian.Ω(; v=0.3, M=M₁ + M₂)
-        Ωₑ = PostNewtonian.Ω(; v=0.4, M=M₁ + M₂)
-
-        inspiral = orbital_evolution(M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; Ωₑ)
-
-        compare_inspiral("inspiral1.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ)
-        compare_inspiral("inspiral2.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; Ω₁=Ωᵢ / 2)
-        compare_inspiral("inspiral3.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; saveat=3.7)
-        compare_inspiral(
-            "inspiral4.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; saveat=inspiral.t[3:7:(end - 9)]
-        )
-        compare_inspiral("inspiral5.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; Ωₑ)
-        compare_inspiral("inspiral6.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; saves_per_orbit=3)
-        compare_inspiral("inspiral7.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=1//2)
-        compare_inspiral("inspiral8.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=3//2)
-        compare_inspiral("inspiral9.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=5//2)
-        compare_inspiral("inspiral10.h5", M₁, M₂, χ⃗₁, χ⃗₂, Ωᵢ; PNOrder=7//2)
-
-        function compare_waveforms(
-            file_name, inspiral, f; ℓₘᵢₙ=2, ℓₘₐₓ=8, PNOrder=typemax(Int)
-        )
-            file_name = joinpath("reference_values", file_name)
-            h = f(inspiral; ℓₘᵢₙ, ℓₘₐₓ, PNOrder)
-            @test_reference file_name Dict("h" => h) by = approx
-        end
-
-        compare_waveforms("waveform1.h5", inspiral, coorbital_waveform)
-        compare_waveforms("waveform2.h5", inspiral, coorbital_waveform; ℓₘᵢₙ=1, ℓₘₐₓ=4)
-        compare_waveforms("waveform3.h5", inspiral, coorbital_waveform; PNOrder=1//2)
-        compare_waveforms("waveform4.h5", inspiral, coorbital_waveform; PNOrder=3//2)
-        compare_waveforms("waveform5.h5", inspiral, coorbital_waveform; PNOrder=5//2)
-        compare_waveforms("waveform6.h5", inspiral, coorbital_waveform; PNOrder=7//2)
-        compare_waveforms("waveform7.h5", inspiral, inertial_waveform)
-        compare_waveforms("waveform8.h5", inspiral, inertial_waveform; ℓₘᵢₙ=1, ℓₘₐₓ=4)
-        compare_waveforms("waveform9.h5", inspiral, inertial_waveform; PNOrder=1//2)
-        compare_waveforms("waveform10.h5", inspiral, inertial_waveform; PNOrder=3//2)
-        compare_waveforms("waveform11.h5", inspiral, inertial_waveform; PNOrder=5//2)
-        compare_waveforms("waveform12.h5", inspiral, inertial_waveform; PNOrder=7//2)
     else
-        @info "We appear to be on CI; skipping reference tests involving ODE integration."
+        @info "We are not running on Julia 1.11; skipping reference tests."
     end
 end


### PR DESCRIPTION
This just adds Λ̃, which is the measurable combination of the individual tidal deformability values.

## Checklist

- [X] I am following the [contributing
  guidelines](https://github.com/moble/PostNewtonian.jl/blob/main/docs/src/contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
