### PR TITLE
Make compatible with FastDifferentiation 0.4.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PostNewtonian"
 uuid = "377afc40-5642-4616-8613-b7ebca523866"
-authors = ["Michael Boyle <michael.oliver.boyle@gmail.com> and contributors"]
 version = "0.10.9"
+authors = ["Michael Boyle <michael.oliver.boyle@gmail.com> and contributors"]
 
 [deps]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
@@ -35,7 +35,7 @@ Aqua = "0.8"
 DataInterpolations = "5.1, 6, 7, 8"
 DoubleFloats = "1.4"
 ExplicitImports = "1.8"
-FastDifferentiation = "0.3.15"
+FastDifferentiation = "0.4.5"
 FileIO = "1.16.3"
 ForwardDiff = "0.10.38, 1"
 HDF5 = "0.17.2"

--- a/src/pn_expressions/binding_energy.jl
+++ b/src/pn_expressions/binding_energy.jl
@@ -183,23 +183,29 @@ function 𝓔′code(
     # Turn that into an Expr (FD insists on making it a function)
     in_place = true
     init_with_zeros = false
-    𝓔′expr = FastDifferentiation.make_Expr(𝓔′, vars, in_place, init_with_zeros)
+    𝓔′expr = FastDifferentiation.make_Expr(𝓔′, vars; in_place, init_with_zeros)
 
     # Now, we use `MacroTools` to get the body of the function.
     𝓔′body = MacroTools.unblock(MacroTools.splitdef(𝓔′expr)[:body])
 
     # At this point, the function is just a long series of statements inside an `@inbounds`
     # block, which we will want later, but first we need to extract them.
-    MacroTools.@capture(𝓔′body, @inbounds begin
-        𝓔′statements__
-    end) || throw(
+    MacroTools.@capture(
+        𝓔′body,
+        begin
+            preamble__
+            @inbounds begin
+                𝓔′statements__
+            end
+        end
+    ) || throw(
         ArgumentError(
             "\nNo @inbounds block found in 𝓔′ expression." *
             "\nSomething may have changed in FastDifferentiation." *
             "\nOpen an issue citing this Julia call:" *
             "\n```julia" *
             "\nusing PostNewtonian" *
-            "\n𝓔′($pnsystem)" *
+            "\n𝓔′($fdpnsystem)" *
             "\n```",
         ),
     )
@@ -214,7 +220,7 @@ function 𝓔′code(
             "\nOpen an issue citing this Julia call:" *
             "\n```julia" *
             "\nusing PostNewtonian" *
-            "\n𝓔′($pnsystem)" *
+            "\n𝓔′($fdpnsystem)" *
             "\n```",
         ),
     )
@@ -224,7 +230,7 @@ function 𝓔′code(
         # When `pn_expansion_reducer=Val(identity)` is passed, we return a PNExpansion
         NMax = Int(2PNOrder + 1)
         return quote
-            input_variables = SVector(pnsystem)
+            input_variables1 = SVector(pnsystem)
             result = MVector{$(length(𝓔′)),$(ScalarType)}(undef)
             result .= 0
             @fastmath @inbounds begin
@@ -235,7 +241,7 @@ function 𝓔′code(
     else
         # Otherwise, FD produces a 1-tuple, so we just extract the value from that.
         return quote
-            input_variables = SVector(pnsystem)
+            input_variables1 = SVector(pnsystem)
             result = MVector{1,$(ScalarType)}(undef)
             result .= 0
             @fastmath @inbounds begin

--- a/src/pn_expressions/separation.jl
+++ b/src/pn_expressions/separation.jl
@@ -202,23 +202,29 @@ from the Newton iterations in [`γₚₙ′`](@ref).
     # Turn that into an Expr (FD insists on making it a function)
     in_place = true
     init_with_zeros = false
-    γₚₙ₀′expr = FastDifferentiation.make_Expr(γₚₙ₀′, vars, in_place, init_with_zeros)
+    γₚₙ₀′expr = FastDifferentiation.make_Expr(γₚₙ₀′, vars; in_place, init_with_zeros)
 
     # Now, we use `MacroTools` to get the body of the function.
     γₚₙ₀′body = MacroTools.unblock(MacroTools.splitdef(γₚₙ₀′expr)[:body])
 
     # # At this point, the function is just a long series of statements inside an `@inbounds`
     # # block, which we will want later, but first we need to extract them.
-    MacroTools.@capture(γₚₙ₀′body, @inbounds begin
-        γₚₙ₀′statements__
-    end) || throw(
+    MacroTools.@capture(
+        γₚₙ₀′body,
+        begin
+            preamble__
+            @inbounds begin
+                γₚₙ₀′statements__
+            end
+        end
+    ) || throw(
         ArgumentError(
             "\nNo @inbounds block found in γₚₙ₀′ expression." *
             "\nSomething may have changed in FastDifferentiation." *
             "\nOpen an issue citing this Julia call:" *
             "\n```julia" *
             "\nusing PostNewtonian" *
-            "\nγₚₙ₀′($pnsystem)" *
+            "\nγₚₙ₀′($fdpnsystem)" *
             "\n```",
         ),
     )
@@ -233,7 +239,7 @@ from the Newton iterations in [`γₚₙ′`](@ref).
             "\nOpen an issue citing this Julia call:" *
             "\n```julia" *
             "\nusing PostNewtonian" *
-            "\nγₚₙ₀′($pnsystem)" *
+            "\nγₚₙ₀′($fdpnsystem)" *
             "\n```",
         ),
     )
@@ -243,7 +249,7 @@ from the Newton iterations in [`γₚₙ′`](@ref).
         # When `pn_expansion_reducer=Val(identity)` is passed, we return a PNExpansion
         NMax = Int(2PNOrder + 1)
         return quote
-            input_variables = SVector(pnsystem)
+            input_variables1 = SVector(pnsystem)
             result = MVector{$(length(γₚₙ₀′)),$(eltype(ST))}(undef)
             result .= 0
             @fastmath @inbounds begin
@@ -254,7 +260,7 @@ from the Newton iterations in [`γₚₙ′`](@ref).
     else
         # Otherwise, FD produces a 1-tuple, so we just extract the value from that.
         return quote
-            input_variables = SVector(pnsystem)
+            input_variables1 = SVector(pnsystem)
             result = MVector{1,$(eltype(ST))}(undef)
             result .= 0
             @fastmath @inbounds begin


### PR DESCRIPTION
<!--
Thanks for making a pull request to PostNewtonian.jl.
We have added this PR template to help you help us.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with the following workflow (i) create issue;
(ii) discussion if necessary; (iii) create PR. So, at least one of
the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #110 (and thereby #120)

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing

<!-- Message of single commit: -->

FD.make_Expr changed so that in_place and init_with_zeros are both keyword args.

The code generation changed to have a bounds checking preamble before the
@inbounds (actual) code block.

The code generation changed to allow for multiple vector args, which means that
the first argument in the code is now named input_variables1 instead of
input_variables.

Minor bugfixes in ArgumentError strings that tried to interpolate the old
variable name $pnsystem instead of $fdpnsystem.